### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @omise/maintainers


### PR DESCRIPTION
## Description

Added a CODEOWNERS file so that reviewers can be automatically assigned to a PR. 

With this change, the `@omise/maintainers` team should be automatically added as reviewers when a PR is raised. 
